### PR TITLE
add rootcling arguments to remove storing of include paths of build

### DIFF
--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -138,6 +138,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   #---call rootcling------------------------------------------
   add_custom_command(OUTPUT ${dictionary}.cxx
                      COMMAND ${ROOTCLING_EXECUTABLE} -f ${dictionary}.cxx
+                                          -noIncludePaths -inlineInputHeader
                                           -c ${ARG_OPTIONS} ${includedirs} ${headerfiles} ${linkdefs}
                      DEPENDS ${headerfiles} ${linkdefs} VERBATIM)
 endfunction()


### PR DESCRIPTION
This PR fixes the error messages from eic-smear when running in a container where the build directory is not accessible. By default rootcling stores the path to the original include file which then causes error messages if the include is not found